### PR TITLE
Fix alignment of rotated labels in bar graph

### DIFF
--- a/jquery.flot.tickrotor.js
+++ b/jquery.flot.tickrotor.js
@@ -154,24 +154,24 @@
                     ctx.font = font;
                     if (rotateTicks <= 90) {
                         // Center such that the top of the label is at the center of the tick.
-                        xoffset = -Math.ceil(Math.cos(radsAboveHoriz) * tick.height);
-                        yoffset = Math.ceil(Math.sin(radsAboveHoriz) * tick.height);
-                        ctx.translate(Math.round(plot.getPlotOffset().left + xaxis.p2c(tick.v)) + xoffset,
-                                      box.top + box.padding + plot.getOptions().grid.labelMargin + yoffset);
+                        xoffset = Math.ceil(Math.cos(radsAboveHoriz) * tick.height/2);
+                        ctx.translate(plot.getPlotOffset().left + xaxis.p2c(tick.v) + xoffset,
+                                      box.top + box.padding);
                         ctx.rotate(rotateTicksRads);
                     } else {
                         // We want the text to facing up, so we have to
                         // rotate counterclockwise, which means the label
                         // has to *end* at the center of the tick.
-                        xoffset = Math.ceil(Math.cos(radsAboveHoriz) * tick.height)
-                                  - Math.ceil(Math.cos(radsAboveHoriz) * tick.width);
-                        yoffset = Math.ceil(Math.sin(radsAboveHoriz) * tick.width)
-                                  + Math.ceil(Math.sin(radsAboveHoriz) * tick.height);
-                        ctx.translate(Math.round(plot.getPlotOffset().left + xaxis.p2c(tick.v) + xoffset),
-                                      box.top + box.padding + plot.getOptions().grid.labelMargin + yoffset);
+                        xoffset = -Math.ceil(Math.sin(radsAboveHoriz) * tick.height/2);
+                        ctx.translate(plot.getPlotOffset().left + xaxis.p2c(tick.v) + xoffset,
+                                      box.top + box.padding);
                         ctx.rotate(-radsAboveHoriz);
+                        ctx.translate(-tick.width, 0);
                     }
-                    ctx.fillText(tick.label, 0, 0);
+
+                    ctx.textBaseline = 'middle';
+
+                    ctx.fillText(tick.label, 0, tick.height / 2);
                     ctx.restore();
                 }
             }


### PR DESCRIPTION
This fixes the label alignment for me with a bar graph.
Can you check if it works well with line graphs as well?
